### PR TITLE
join-channel-into-parameter-options.nf, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.nextflow*

--- a/join-channel-into-parameter-options.nf
+++ b/join-channel-into-parameter-options.nf
@@ -1,0 +1,24 @@
+
+
+Channel.from( [1,2,3,4,5])
+.collect()
+// .view()
+.set{ ch_a }
+
+process foo {
+  input: val f from ch_a
+  output:
+    stdout myout
+
+
+  script:
+
+  combined = f.join(' --input ')
+
+  """
+    echo command --input ${combined}
+  echo ""
+  """
+}
+
+myout.subscribe { print "$it"}

--- a/join-channel-into-parameter-options.nf
+++ b/join-channel-into-parameter-options.nf
@@ -1,23 +1,23 @@
-
+// a common pattern is to have a command take a single option multiple times
+// and this option can be used to do things like merge collected outputs
+// together in a single process.  e.g.:
+//   command --option 1 --option 2 --option 3 [...]
 
 Channel.from( [1,2,3,4,5])
-.collect()
-// .view()
 .set{ ch_a }
 
 process foo {
-  input: val f from ch_a
+  input: val f from ch_a.collect()
   output:
     stdout myout
 
-
   script:
 
-  combined = f.join(' --input ')
+  combined = f.join(' --option ')
 
   """
-    echo command --input ${combined}
-  echo ""
+    echo command --option ${combined}
+    echo ""
   """
 }
 


### PR DESCRIPTION
This pull request does two things:

1.  it adds a .gitignore containing ".nextflow*", so we can test idioms in place and not pollute the .git repo
2.  it adds a "join-channel-into-parameter-options.nf" which shows how to take a channel and use it with a repeated command-line option.  e.g. it if the channel is `[1, 2, 3]` you can use it as `command --option 1 --option 2 --option 3 [...]`
